### PR TITLE
Allow gen to run on clean directory each time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ keywords = ["no-std", "arm", "cortex-m", "efm32"]
 readme = "readme.md"
 repository = "https://github.com/jacobrosenthal/efm32"
 
+[[bin]]
+name = "gen"
+path = "tools/src/bin/gen.rs"
+
 [dependencies]
 bare-metal = "0.2.0"
 cortex-m = "0.5.8"

--- a/readme.md
+++ b/readme.md
@@ -4,9 +4,13 @@ board support package for EFM32 Happy Gecko series from Silicon Labs
 
 The EFM32HG register definitions are from from keil.com and provided here in /svd.
 
+documentation
+--
+Overview for peripheral access usage can be found [here](https://docs.rs/svd2rust/0.12.0/svd2rust/#peripheral-api).
+
 regenerate
 --
+This will require Rust 1.31 or newer.
 ```
-rm -rf src && mkdir src && touch src/lib.rs && cargo gen
+cargo gen
 ```
-

--- a/tools/src/bin/gen.rs
+++ b/tools/src/bin/gen.rs
@@ -47,7 +47,7 @@ pub fn main() -> () {
     }
 
     set_current_dir("..").unwrap();
-    remove_dir_all("./src").unwrap();
+    remove_dir_all("./src").unwrap_or_else(|err| println!("./src: {} [ignored]", err));
     rename(".tmp/build.rs", "./build.rs").unwrap();
     rename(".tmp/device.x", "./device.x").unwrap();
     rename(".tmp/src", "./src").unwrap();

--- a/tools/src/bin/gen.rs
+++ b/tools/src/bin/gen.rs
@@ -1,6 +1,7 @@
 use form::create_directory_structure;
 use rustfmt_nightly::{Config, Input, Session};
-use std::fs::{read_to_string, File};
+use std::env::set_current_dir;
+use std::fs::{create_dir_all, read_to_string, remove_dir_all, rename, File};
 use std::io::Write;
 use std::path::PathBuf;
 use svd2rust::{generate, Generation, Target::CortexM};
@@ -15,6 +16,9 @@ pub fn main() -> () {
     } = generate(&xml, &CortexM, true).unwrap();
 
     let device_specific = device_specific.unwrap();
+
+    create_dir_all(".tmp/src").unwrap();
+    set_current_dir(".tmp").unwrap();
 
     //save other files
     writeln!(
@@ -41,4 +45,11 @@ pub fn main() -> () {
     for path in files {
         session.format(Input::File(path)).unwrap();
     }
+
+    set_current_dir("..").unwrap();
+    remove_dir_all("./src").unwrap();
+    rename(".tmp/build.rs", "./build.rs").unwrap();
+    rename(".tmp/device.x", "./device.x").unwrap();
+    rename(".tmp/src", "./src").unwrap();
+    remove_dir_all(".tmp").unwrap();
 }


### PR DESCRIPTION
Wondering if this would be in favor, also this might be already attempted, allow `cargo gen` to be called on its own.

`[[bin]]` is required to allow cargo to run without src dir.